### PR TITLE
Fix TOCTOU

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,15 +143,17 @@ impl AwaitableBool {
     /// Wait for this [`AwaitableBool`]'s value to become `true`.
     /// This returns immediately if it's already `true`.
     pub async fn wait_true(&self) {
+        let wait_fut = self.wait();
         if self.is_false() {
-            self.wait().await;
+            wait_fut.await;
         }
     }
     /// Wait for this [`AwaitableBool`]'s value to become `false`.
     /// This returns immediately if it's already `false`.
     pub async fn wait_false(&self) {
+        let wait_fut = self.wait();
         if self.is_true() {
-            self.wait().await;
+            wait_fut.await;
         }
     }
 


### PR DESCRIPTION
Because of how `notify_waiters` works (as opposed to `notify_one`), it's critical to construct the `Notified` future _before_ checking the condition. Otherwise, there's a race condition where after checking the condition, the notify happens, and _then_ the future is constructed, so the `wait_true`/`wait_false` function could end up not returning.

At first glance, this solution suffers from the exact _opposite_ problem. What if due to a race, we receive a "wrong-way" notify?

Normally, the solution for this would be to use a loop eg:

```
    pub async fn wait_true(&self) {
        let mut wait_fut = self.wait();
        while self.is_false() {
            wait_fut.await;
            wait_fut = self.wait();
        }
    }
```

But I think in this case that's unnecessary specifically because `bool` is two-valued and notifies only happen on toggles. If we receive a wrong-way notify, that indicates that another thread has successfully toggled the value in parallel with this call (either through `toggle` or `set_false`), which means when _that_ thread started calling the function, the value must have been true. As a result, returning immediately from the caller's perspective is indistinguishable from the case where this thread "won" the race and `wait_true` was called _before_ the toggle.